### PR TITLE
VoxelCommonLiteMod compat with non-Windows operating systems

### DIFF
--- a/src/main/java/com/midnight/liteloaderloader/core/LiteloaderTransformer.java
+++ b/src/main/java/com/midnight/liteloaderloader/core/LiteloaderTransformer.java
@@ -30,6 +30,7 @@ import org.spongepowered.asm.lib.MethodVisitor;
 import com.midnight.liteloaderloader.core.transformers.ClassOverlayTransformerTransformer;
 import com.midnight.liteloaderloader.core.transformers.EventTransformer;
 import com.midnight.liteloaderloader.core.transformers.compat.AngelicaHUDCachingTransformer;
+import com.midnight.liteloaderloader.core.transformers.compat.VoxelCommonLiteModTransformer;
 import com.midnight.liteloaderloader.lib.Tuple;
 
 @SuppressWarnings("unused")
@@ -74,6 +75,12 @@ public class LiteloaderTransformer implements IClassTransformer {
             "com.mumfrey.liteloader.transformers.ClassOverlayTransformer",
             bytes -> new ClassOverlayTransformerTransformer().apply(bytes));
 
+        // VoxelCommonLiteMod uses a hardcoded TEMP environment variable, which only exists on Windows.
+        // We replace it with java.io.tmpdir property, which is the standard temporary directory for Java.
+        transformations.put(
+            "com.thevoxelbox.common.VoxelCommonLiteMod",
+            bytes -> new VoxelCommonLiteModTransformer().apply(bytes));
+
         // com.mumfrey.liteloader
 
         toKill.put("CrashReportTransformer", Tuple.of("transform", Tuple.of(ARETURN, 3)));
@@ -93,7 +100,6 @@ public class LiteloaderTransformer implements IClassTransformer {
 
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
-
         if (basicClass == null) return null;
         if (transformations.containsKey(transformedName)) {
             LOG.info("Applying transformation for {}", transformedName);

--- a/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/AngelicaHUDCachingTransformer.java
+++ b/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/AngelicaHUDCachingTransformer.java
@@ -31,7 +31,7 @@ public class AngelicaHUDCachingTransformer extends ClassTransformer {
 
         list = callFunction("throwPostEvents");
         AbstractInsnNode last;
-        //noinspection StatementWithEmptyBody
+        // noinspection StatementWithEmptyBody
         for (last = methodNode.instructions.getLast(); last.getOpcode() != Opcodes.RETURN; last = last.getPrevious());
         methodNode.instructions.insertBefore(last, list);
     }

--- a/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/VoxelCommonLiteModTransformer.java
+++ b/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/VoxelCommonLiteModTransformer.java
@@ -1,7 +1,42 @@
 package com.midnight.liteloaderloader.core.transformers.compat;
 
+import org.spongepowered.asm.lib.tree.AbstractInsnNode;
+import org.spongepowered.asm.lib.tree.LdcInsnNode;
+import org.spongepowered.asm.lib.tree.MethodInsnNode;
+import org.spongepowered.asm.lib.tree.MethodNode;
+
 import com.midnight.liteloaderloader.core.transformers.ClassTransformer;
 
-public class MineLPLinuxCompat extends ClassTransformer {
-    
+import scala.tools.asm.Opcodes;
+
+public class VoxelCommonLiteModTransformer extends ClassTransformer {
+
+    public VoxelCommonLiteModTransformer() {
+        super();
+        methodTransforms.put("<clinit>", this::transformStaticInit);
+        methodTransforms.put("init", this::transformInit);
+    }
+
+    private void transformStaticInit(MethodNode methodNode) {
+        for (AbstractInsnNode node : methodNode.instructions.toArray()) {
+            if (node instanceof LdcInsnNode ldcNode) {
+                if (ldcNode.cst.equals("TEMP")) {
+                    ldcNode.cst = "java.io.tmpdir";
+                    return;
+                }
+            }
+        }
+    }
+
+    private void transformInit(MethodNode methodNode) {
+        for (AbstractInsnNode node : methodNode.instructions.toArray()) {
+            if (node instanceof MethodInsnNode methodInsnNode) {
+                if (methodInsnNode.getOpcode() == Opcodes.INVOKESTATIC) {
+                    if (methodInsnNode.name.equals("getenv")) {
+                        methodInsnNode.name = "getProperty";
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/VoxelCommonLiteModTransformer.java
+++ b/src/main/java/com/midnight/liteloaderloader/core/transformers/compat/VoxelCommonLiteModTransformer.java
@@ -1,0 +1,7 @@
+package com.midnight.liteloaderloader.core.transformers.compat;
+
+import com.midnight.liteloaderloader.core.transformers.ClassTransformer;
+
+public class MineLPLinuxCompat extends ClassTransformer {
+    
+}


### PR DESCRIPTION
VoxelCommonLiteMod uses a hardcoded TEMP environment variable instead of using the java.io.tmpdir system property.